### PR TITLE
Adding cgroup support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,14 @@
 
 ### **Breaking changes**
 
-* `systemd_unit_state` no longer returns a `type` label
+* `systemd_unit_state` label `type` has new meaning
+   Now shows Unit type (`service`, `scope`, etc), not Service Unit types (`simple`, `forking`, etc)
+   or mount unit types(`aufs`,`ext3`, etc). Service and mount types have been moved to `systemd_unit_info` 
 
 ### Changes
 
+* [ENHANCEMENT] Read unit CPU usage from cgroup, add `systemd_unit_cpu_seconds_total` metric
+* [ENHANCEMENT] Add `type` label to all metrics named `systemd_unit-*` 
 * [ENHANCEMENT] `systemd_unit_state` works for all unit types, just service and mount units
 * [FEATURE] Add `systemd_unit_info` with metainformation about units incl. subtype specific info
 * [CHANGE] Expanded default set of unit types monitored. Only device unit types are not enabled by default

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 - [FEATURE] Read unit CPU usage from cgroup. Added `systemd_unit_cpu_seconds_total` metric. **Note** - Untested on unified hierarchy
 - [FEATURE] Add `systemd_unit_info` with metainformation about units incl. subtype specific info
 - [ENHANCEMENT] Added `type` label to all metrics named `systemd_unit-*` to support PromQL grouping
-* [ENHANCEMENT] `systemd_unit_state` works for all unit types, just service and mount units
+* [ENHANCEMENT] `systemd_unit_state` works for all unit types, not just service and mount units
 * [CHANGE] Start tracking metric cardinality in readme
 * [CHANGE] Expanded default set of unit types monitored. Only device unit types are not enabled by default
 * [BUGFIX] `timer_last_trigger_seconds` metric is now exported as expected for all timers

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,13 @@
 
 ### Changes
 
-* [ENHANCEMENT] Read unit CPU usage from cgroup, add `systemd_unit_cpu_seconds_total` metric
-* [ENHANCEMENT] Add `type` label to all metrics named `systemd_unit-*` 
+- [FEATURE] Read unit CPU usage from cgroup. Added `systemd_unit_cpu_seconds_total` metric. **Note** - Untested on unified hierarchy
+- [FEATURE] Add `systemd_unit_info` with metainformation about units incl. subtype specific info
+- [ENHANCEMENT] Added `type` label to all metrics named `systemd_unit-*` to support PromQL grouping
 * [ENHANCEMENT] `systemd_unit_state` works for all unit types, just service and mount units
-* [FEATURE] Add `systemd_unit_info` with metainformation about units incl. subtype specific info
+* [CHANGE] Start tracking metric cardinality in readme
 * [CHANGE] Expanded default set of unit types monitored. Only device unit types are not enabled by default
+* [BUGFIX] `timer_last_trigger_seconds` metric is now exported as expected for all timers
 
 ## 0.2.0 / 2019-03-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 ### Changes
 
 * [ENHANCEMENT] `systemd_unit_state` works for all unit types, just service and mount units
+* [FEATURE] Add `systemd_unit_info` with metainformation about units incl. subtype specific info
 
 ## 0.2.0 / 2019-03-20
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,13 @@
+## master / unreleased
+
+### **Breaking changes**
+
+* `systemd_unit_state` no longer returns a `type` label
+
+### Changes
+
+* [ENHANCEMENT] `systemd_unit_state` works for all unit types, just service and mount units
+
+## 0.2.0 / 2019-03-20
+
+* [CLEANUP] Introduced changelog. From now on, changes will be reported in this file.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 * [ENHANCEMENT] `systemd_unit_state` works for all unit types, just service and mount units
 * [FEATURE] Add `systemd_unit_info` with metainformation about units incl. subtype specific info
+* [CHANGE] Expanded default set of unit types monitored. Only device unit types are not enabled by default
 
 ## 0.2.0 / 2019-03-20
 

--- a/README.md
+++ b/README.md
@@ -46,23 +46,28 @@ User need to access systemd dbus, `/proc` for exporter to work.
 
 # Metrics
 
-All metrics have `name` label, which contains systemd unit name. For example `name="bluetooh.service"` or `name="systemd-coredump.socket"`.
+All metrics have `name` label, which contains systemd unit name. For example `name="bluetooth.service"` or `name="systemd-coredump.socket"`.
 
-Metric name| Metric type | Status |
----------- | ----------- | ----------- |
-systemd_unit_state | Gauge |  UNSTABLE
-systemd_unit_tasks_current | Gauge | UNSTABLE
-systemd_unit_tasks_max | Gauge | UNSTABLE
-systemd_unit_start_time_seconds | Gauge |  UNSTABLE
-systemd_service_restart_total | Gauge |  UNSTABLE
-systemd_socket_accepted_connections_total | Counter | UNSTABLE
-systemd_timer_last_trigger_seconds | Gauge | UNSTABLE
-systemd_socket_current_connections | Gauge | UNSTABLE
-systemd_socket_refused_connections_total | Gauge | UNSTABLE
-systemd_process_resident_memory_bytes| Gauge | UNSTABLE
-systemd_process_virtual_memory_bytes | Gauge | UNSTABLE
-systemd_process_virtual_memory_max_bytes | Gauge |  UNSTABLE
-systemd_process_open_fds | Gauge | UNSTABLE
-systemd_process_max_fds | Gauge | UNSTABLE
-systemd_process_cpu_seconds_total | Counter | UNSTABLE
+Note that a number of unit types are filtered by default
+
+Metric name                               | Metric type | Status      | Cardinality |
+----------------------------------------- | ----------- | ----------- | ----------- |
+systemd_exporter_build_info               | Gauge       |  UNSTABLE   | 1 per systemd-exporter 
+systemd_unit_info                         | Gauge       |  UNSTABLE   | 1 per service + 1 per mount 
+systemd_unit_cpu_seconds_total            | Gauge       |  UNSTABLE   | 2 per unit {mode="system|user"}         
+systemd_unit_state                        | Gauge       |  UNSTABLE   | 5 per unit {state="activating|active|deactivating|failed|inactive}            
+systemd_unit_tasks_current                | Gauge       |  UNSTABLE
+systemd_unit_tasks_max                    | Gauge       |  UNSTABLE
+systemd_unit_start_time_seconds           | Gauge       |  UNSTABLE
+systemd_service_restart_total             | Gauge       |  UNSTABLE
+systemd_socket_accepted_connections_total | Counter     |  UNSTABLE   | 1 per socket
+systemd_socket_current_connections        | Gauge       |  UNSTABLE   | 1 per socket
+systemd_socket_refused_connections_total  | Gauge       |  UNSTABLE
+systemd_timer_last_trigger_seconds        | Gauge       |  UNSTABLE
+systemd_process_resident_memory_bytes     | Gauge       |  UNSTABLE   | 1 per service
+systemd_process_virtual_memory_bytes      | Gauge       |  UNSTABLE   | 1 per service
+systemd_process_virtual_memory_max_bytes  | Gauge       |  UNSTABLE   | 1 per service
+systemd_process_open_fds                  | Gauge       |  UNSTABLE   | 1 per service
+systemd_process_max_fds                   | Gauge       |  UNSTABLE   | 1 per service
+systemd_process_cpu_seconds_total         | Counter     |  UNSTABLE   | 1 per service
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,11 @@ User need to access systemd dbus, `/proc`, `/sys/fs/cgroup` for exporter to work
 
 # Metrics
 
-All metrics have `name` label, which contains systemd unit name. For example `name="bluetooth.service"` or `name="systemd-coredump.socket"`.
+All metrics have `name` label, which contains systemd unit name. For example 
+`name="bluetooth.service"` or `name="systemd-coredump.socket"`. Metrics that 
+are present for all units (e.g. those named `unit_*`) additionally have a 
+label type e.g. (`type="socket"` or `type="service"`) to allow usage in 
+PromQL grouping queries (e.g. `count(systemd_unit_state) by (type)`)
 
 Note that a number of unit types are filtered by default
 

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ advantage of systemd's builtin process and thread grouping to provide applicatio
 | process-exporter | Focus is on individual processes                | CPU of specific process ID (e.g. `1127`)
 
 Systemd groups processes, threads, and other resources (PIDs, memory, etc) into logical containers 
-called units. Systemd-exporter will read the 12 different types of systemd units (e.g. service, slice, etc)
+called units. Systemd-exporter will read the 11 different types of systemd units (e.g. service, slice, etc)
 and give you metrics about the health and resource consumption of each unit. This allows an application
 specific view of your system, allowing you to determine resource usage of an application such as 
 `mysql.service` independently from the resources used by other processes on your system.
@@ -61,7 +61,7 @@ Take a look at `examples` for daemonset manifests for Kubernetes.
 
 # User privilleges
 
-User need to access systemd dbus, `/proc` for exporter to work.
+User need to access systemd dbus, `/proc`, `/sys/fs/cgroup` for exporter to work.
 
 # Metrics
 
@@ -73,7 +73,7 @@ Metric name                               | Metric type | Status      | Cardinal
 ----------------------------------------- | ----------- | ----------- | ----------- |
 systemd_exporter_build_info               | Gauge       |  UNSTABLE   | 1 per systemd-exporter 
 systemd_unit_info                         | Gauge       |  UNSTABLE   | 1 per service + 1 per mount 
-systemd_unit_cpu_seconds_total            | Gauge       |  UNSTABLE   | 2 per unit {mode="system|user"}         
+systemd_unit_cpu_seconds_total            | Gauge       |  UNSTABLE   | 2 per mount|scope|slice|socket|swap {mode="system|user"}         
 systemd_unit_state                        | Gauge       |  UNSTABLE   | 5 per unit {state="activating|active|deactivating|failed|inactive}            
 systemd_unit_tasks_current                | Gauge       |  UNSTABLE
 systemd_unit_tasks_max                    | Gauge       |  UNSTABLE

--- a/README.md
+++ b/README.md
@@ -12,12 +12,12 @@ Prometheus exporter for systemd units, written in Go.
 The focus on each exporter is different. node-exporter has a broad focus, and process-exporter
 is focused on deep analysis of specific processes. systemd-exporter aims to fit in the middle, taking 
 advantage of systemd's builtin process and thread grouping to provide application-level metrics. 
- 
-| Exporter         | Metric Goals                                    | Example                     
-| ---------------- | ----------------------------------------------- | --------------------------- 
-| node-exporter    | Machine-wide monitoring and usage summary       | CPU usage of entire node (e.g. `127.0.0.1`)
-| systemd-exporter | Systemd unit monitoring and resource usage      | CPU usage of each service (e.g. `mongodb.service`)       
-| process-exporter | Focus is on individual processes                | CPU of specific process ID (e.g. `1127`)
+
+| Exporter         | Metric Goals                               | Example                                            |
+| ---------------- | ------------------------------------------ | -------------------------------------------------- |
+| node-exporter    | Machine-wide monitoring and usage summary  | CPU usage of entire node (e.g. `127.0.0.1`)        |
+| systemd-exporter | Systemd unit monitoring and resource usage | CPU usage of each service (e.g. `mongodb.service`) |
+| process-exporter | Focus is on individual processes           | CPU of specific process ID (e.g. `1127`)           |
 
 Systemd groups processes, threads, and other resources (PIDs, memory, etc) into logical containers 
 called units. Systemd-exporter will read the 11 different types of systemd units (e.g. service, slice, etc)
@@ -75,24 +75,23 @@ PromQL grouping queries (e.g. `count(systemd_unit_state) by (type)`)
 
 Note that a number of unit types are filtered by default
 
-Metric name                               | Metric type | Status      | Cardinality |
------------------------------------------ | ----------- | ----------- | ----------- |
-systemd_exporter_build_info               | Gauge       |  UNSTABLE   | 1 per systemd-exporter 
-systemd_unit_info                         | Gauge       |  UNSTABLE   | 1 per service + 1 per mount 
-systemd_unit_cpu_seconds_total            | Gauge       |  UNSTABLE   | 2 per mount|scope|slice|socket|swap {mode="system|user"}         
-systemd_unit_state                        | Gauge       |  UNSTABLE   | 5 per unit {state="activating|active|deactivating|failed|inactive}            
-systemd_unit_tasks_current                | Gauge       |  UNSTABLE
-systemd_unit_tasks_max                    | Gauge       |  UNSTABLE
-systemd_unit_start_time_seconds           | Gauge       |  UNSTABLE
-systemd_service_restart_total             | Gauge       |  UNSTABLE
-systemd_socket_accepted_connections_total | Counter     |  UNSTABLE   | 1 per socket
-systemd_socket_current_connections        | Gauge       |  UNSTABLE   | 1 per socket
-systemd_socket_refused_connections_total  | Gauge       |  UNSTABLE
-systemd_timer_last_trigger_seconds        | Gauge       |  UNSTABLE
-systemd_process_resident_memory_bytes     | Gauge       |  UNSTABLE   | 1 per service
-systemd_process_virtual_memory_bytes      | Gauge       |  UNSTABLE   | 1 per service
-systemd_process_virtual_memory_max_bytes  | Gauge       |  UNSTABLE   | 1 per service
-systemd_process_open_fds                  | Gauge       |  UNSTABLE   | 1 per service
-systemd_process_max_fds                   | Gauge       |  UNSTABLE   | 1 per service
-systemd_process_cpu_seconds_total         | Counter     |  UNSTABLE   | 1 per service
-
+| Metric name                               | Metric type | Status   | Cardinality                                                        |
+| ----------------------------------------- | ----------- | -------- | ------------------------------------------------------------------ |
+| systemd_exporter_build_info               | Gauge       | UNSTABLE | 1 per systemd-exporter                                             |
+| systemd_unit_info                         | Gauge       | UNSTABLE | 1 per service + 1 per mount                                        |
+| systemd_unit_cpu_seconds_total            | Gauge       | UNSTABLE | 2 per mount/scope/slice/socket/swap {mode="system/user"}           |
+| systemd_unit_state                        | Gauge       | UNSTABLE | 5 per unit {state="activating/active/deactivating/failed/inactive} |
+| systemd_unit_tasks_current                | Gauge       | UNSTABLE | 1 per service                                                      |
+| systemd_unit_tasks_max                    | Gauge       | UNSTABLE | 1 per service                                                      |
+| systemd_unit_start_time_seconds           | Gauge       | UNSTABLE | 1 per service                                                      |
+| systemd_service_restart_total             | Gauge       | UNSTABLE | 1 per service                                                      |
+| systemd_socket_accepted_connections_total | Counter     | UNSTABLE | 1 per socket                                                       |
+| systemd_socket_current_connections        | Gauge       | UNSTABLE | 1 per socket                                                       |
+| systemd_socket_refused_connections_total  | Gauge       | UNSTABLE | 1 per socket                                                       |
+| systemd_timer_last_trigger_seconds        | Gauge       | UNSTABLE | 1 per timer                                                        |
+| systemd_process_resident_memory_bytes     | Gauge       | UNSTABLE | 1 per service                                                      |
+| systemd_process_virtual_memory_bytes      | Gauge       | UNSTABLE | 1 per service                                                      |
+| systemd_process_virtual_memory_max_bytes  | Gauge       | UNSTABLE | 1 per service                                                      |
+| systemd_process_open_fds                  | Gauge       | UNSTABLE | 1 per service                                                      |
+| systemd_process_max_fds                   | Gauge       | UNSTABLE | 1 per service                                                      |
+| systemd_process_cpu_seconds_total         | Counter     | UNSTABLE | 1 per service                                                      |

--- a/README.md
+++ b/README.md
@@ -55,6 +55,8 @@ Name     | Description |
 --collector.enable-restart-count | Enables service restart count metrics. This feature only works with systemd 235 and above.
 --collector.enable-file-descriptor-size | Enables file descriptor size metrics. Systemd Exporter needs access to /proc/X/fd files.
 
+Of note, there is no customized support for `.snapshot` (removed in systemd v228), `.busname` (only present on systems using kdbus), `generated` (created via generators), `transient` (created during systemd-run) have no special support. 
+
 # Deployment
 
 Take a look at `examples` for daemonset manifests for Kubernetes.

--- a/main.go
+++ b/main.go
@@ -47,7 +47,7 @@ func main() {
 	r.MustRegister(version.NewCollector("systemd_exporter"))
 	r.MustRegister(prommod.NewCollector("systemd_exporter"))
 
-	collector, err := systemd.NewSystemdCollector(log.Base())
+	collector, err := systemd.NewCollector(log.Base())
 	if err != nil {
 		log.Fatalf("couldn't create collector: %s", err)
 	}

--- a/main.go
+++ b/main.go
@@ -47,7 +47,7 @@ func main() {
 	r.MustRegister(version.NewCollector("systemd_exporter"))
 	r.MustRegister(prommod.NewCollector("systemd_exporter"))
 
-	collector, err := systemd.NewCollector(log.Base())
+	collector, err := systemd.NewSystemdCollector(log.Base())
 	if err != nil {
 		log.Fatalf("couldn't create collector: %s", err)
 	}

--- a/systemd/cgroups.go
+++ b/systemd/cgroups.go
@@ -97,11 +97,11 @@ func cgUnifiedCached() (*CgroupUnified, error) {
 				log.Debugf("Found cgroup on /sys/fs/cgroup/systemd, legacy hierarchy")
 				cgroupUnified = &none
 			default:
-				return nil, errors.Wrapf(err, "Unknown magic number %x for fstype returned by statfs(/sys/fs/cgroup/systemd)", fs.Type)
+				return nil, errors.Errorf("Unknown magic number %x for fstype returned by statfs(/sys/fs/cgroup/systemd)", fs.Type)
 			}
 		}
 	default:
-		return nil, errors.Wrapf(err, "Unknown magic number %x for fstype returned by statfs(/sys/fs/cgroup)", fs.Type)
+		return nil, errors.Errorf("Unknown magic number %x for fstype returned by statfs(/sys/fs/cgroup)", fs.Type)
 	}
 
 	return cgroupUnified, nil
@@ -220,17 +220,17 @@ func NewCPUAcct(CGSubpath string) (*CPUAcct, error) {
 
 	scanner := bufio.NewScanner(bytes.NewReader(b))
 	scanner.Scan()
-	if scanner.Err() != nil {
+	if err := scanner.Err(); err != nil {
 		return nil, errors.Wrapf(err, "Unable to scan file %s", CGPath)
 	}
 	for scanner.Scan() {
-		if scanner.Err() != nil {
+		if err := scanner.Err(); err != nil {
 			return nil, errors.Wrapf(err, "Unable to scan file %s", CGPath)
 		}
 		text := scanner.Text()
 		vals := strings.Split(text, " ")
 		if len(vals) != 3 {
-			return nil, errors.Wrapf(err, "Unable to parse contents of file %s", CGPath)
+			return nil, errors.Errorf("Unable to parse contents of file %s", CGPath)
 		}
 		cpu, err := strconv.ParseUint(vals[0], 10, 32)
 		if err != nil {
@@ -252,7 +252,7 @@ func NewCPUAcct(CGSubpath string) (*CPUAcct, error) {
 		cpuUsage.CPUs = append(cpuUsage.CPUs, onecpu)
 	}
 	if len(cpuUsage.CPUs) < 1 {
-		return nil, errors.Wrapf(err, "Found no CPUs information inside %s", CGPath)
+		return nil, errors.Errorf("Found no CPUs information inside %s", CGPath)
 	}
 
 	return &cpuUsage, nil

--- a/systemd/cgroups.go
+++ b/systemd/cgroups.go
@@ -51,9 +51,9 @@ var cgroupUnified cgUnifiedMountMode = unifModeUnknown
 
 // Values copied from https://github.com/torvalds/linux/blob/master/include/uapi/linux/magic.h
 const (
-	TMPFS_MAGIC         = 0x01021994
-	CGROUP_SUPER_MAGIC  = 0x27e0eb
-	CGROUP2_SUPER_MAGIC = 0x63677270
+	tmpFsMagic        = 0x01021994
+	cgroupSuperMagic  = 0x27e0eb
+	cgroup2SuperMagic = 0x63677270
 )
 
 // cgUnifiedCached checks the filesystem types mounted under /sys/fs/cgroup to determine
@@ -76,14 +76,14 @@ func cgUnifiedCached() (cgUnifiedMountMode, error) {
 	}
 
 	switch fs.Type {
-	case CGROUP2_SUPER_MAGIC:
+	case cgroup2SuperMagic:
 		log.Debugf("Found cgroup2 on /sys/fs/cgroup, full unified hierarchy")
 		cgroupUnified = unifModeAll
-	case TMPFS_MAGIC:
+	case tmpFsMagic:
 		err := unix.Statfs("/sys/fs/cgroup/unified", &fs)
 
 		// Ignore err, we expect path to be missing on v232
-		if err == nil && fs.Type == CGROUP2_SUPER_MAGIC {
+		if err == nil && fs.Type == cgroup2SuperMagic {
 			log.Debugf("Found cgroup2 on /sys/fs/cgroup/systemd, unified hierarchy for systemd controller")
 			cgroupUnified = unifModeSystemd
 		} else {
@@ -92,10 +92,10 @@ func cgUnifiedCached() (cgUnifiedMountMode, error) {
 				return unifModeUnknown, errors.Wrapf(err, "failed statfs(/sys/fs/cgroup/systemd)")
 			}
 			switch fs.Type {
-			case CGROUP2_SUPER_MAGIC:
+			case cgroup2SuperMagic:
 				log.Debugf("Found cgroup2 on /sys/fs/cgroup/systemd, unified hierarchy for systemd controller (v232 variant)")
 				cgroupUnified = unifModeSystemd
-			case CGROUP_SUPER_MAGIC:
+			case cgroupSuperMagic:
 				log.Debugf("Found cgroup on /sys/fs/cgroup/systemd, legacy hierarchy")
 				cgroupUnified = unifModeNone
 			default:

--- a/systemd/cgroups.go
+++ b/systemd/cgroups.go
@@ -97,7 +97,13 @@ func NewCPUAcct(CGSubpath string) (*CPUAcct, error) {
 
 	scanner := bufio.NewScanner(bytes.NewReader(b))
 	scanner.Scan()
+	if scanner.Err() != nil {
+		return nil, errors.Wrapf(err, "Unable to scan file %s", CGPath)
+	}
 	for scanner.Scan() {
+		if scanner.Err() != nil {
+			return nil, errors.Wrapf(err, "Unable to scan file %s", CGPath)
+		}
 		text := scanner.Text()
 		vals := strings.Split(text, " ")
 		if len(vals) != 3 {
@@ -115,10 +121,11 @@ func NewCPUAcct(CGSubpath string) (*CPUAcct, error) {
 		if err != nil {
 			return nil, errors.Wrapf(err, "Unable to parse %s as an in (from %s)", vals[2], CGPath)
 		}
-		var onecpu CPUUsage
-		onecpu.CPUId = uint32(cpu)
-		onecpu.UserNanosec = user
-		onecpu.SystemNanosec = sys
+		onecpu := CPUUsage{
+			CPUId:         uint32(cpu),
+			UserNanosec:   user,
+			SystemNanosec: sys,
+		}
 		cpuUsage.CPUs = append(cpuUsage.CPUs, onecpu)
 	}
 	if len(cpuUsage.CPUs) < 1 {

--- a/systemd/cgroups.go
+++ b/systemd/cgroups.go
@@ -28,31 +28,34 @@ type CPUAcct struct {
 	CPUs []CPUUsage
 }
 
-// UsageUser returns user (e.g. non-kernel) cpu consumption in nanoseconds, across all available cpu
+// UsageUserNanosecs returns user (e.g. non-kernel) cpu consumption in nanoseconds, across all available cpu
 // cores, from the point that CPU accounting was enabled for this control group.
-func (c *CPUAcct) UsageUser() (nanoseconds uint64) {
+func (c *CPUAcct) UsageUserNanosecs() uint64 {
+	var nanoseconds uint64
 	for _, cpu := range c.CPUs {
 		nanoseconds += cpu.UserNanosec
 	}
-	return
+	return nanoseconds
 }
 
-// UsageSystem returns system (e.g. kernel) cpu consumption in nanoseconds, across all available cpu
+// UsageSystemNanosecs returns system (e.g. kernel) cpu consumption in nanoseconds, across all available cpu
 // cores, from the point that CPU accounting was enabled for this control group.
-func (c *CPUAcct) UsageSystem() (nanoseconds uint64) {
+func (c *CPUAcct) UsageSystemNanosecs() uint64 {
+	var nanoseconds uint64
 	for _, cpu := range c.CPUs {
 		nanoseconds += cpu.SystemNanosec
 	}
-	return
+	return nanoseconds
 }
 
-// UsageAll returns total cpu consumption in nanoseconds, across all available cpu
+// UsageAllNanosecs returns total cpu consumption in nanoseconds, across all available cpu
 // cores, from the point that CPU accounting was enabled for this control group.
-func (c *CPUAcct) UsageAll() (nanoseconds uint64) {
+func (c *CPUAcct) UsageAllNanosecs() uint64 {
+	var nanoseconds uint64
 	for _, cpu := range c.CPUs {
 		nanoseconds += cpu.SystemNanosec + cpu.UserNanosec
 	}
-	return
+	return nanoseconds
 }
 
 // ReadFileNoStat uses ioutil.ReadAll to read contents of entire file.

--- a/systemd/cgroups.go
+++ b/systemd/cgroups.go
@@ -1,0 +1,120 @@
+package systemd
+
+import (
+	"bufio"
+	"bytes"
+	"io"
+	"io/ioutil"
+	"os"
+	"strconv"
+	"strings"
+
+	"github.com/pkg/errors"
+	"github.com/prometheus/common/log"
+)
+
+type CPUUsageOne struct {
+	cpu_id             uint32
+	usage_sys_nanosec  uint64
+	usage_user_nanosec uint64
+}
+
+// Holds contents of /sys/fs/cgroup/..../cpuacct.usage_all
+type CPUAcct struct {
+	cpu []CPUUsageOne
+}
+
+func (c *CPUAcct) usage_user_nanosec() uint64 {
+	var all uint64
+	for _, cpu := range c.cpu {
+		all += cpu.usage_user_nanosec
+	}
+	return all
+}
+
+func (c *CPUAcct) usage_sys_nanosec() uint64 {
+	var all uint64
+	for _, cpu := range c.cpu {
+		all += cpu.usage_sys_nanosec
+	}
+	return all
+}
+
+func (c *CPUAcct) usage_all_nanosec() uint64 {
+	var all uint64
+	for _, cpu := range c.cpu {
+		all += cpu.usage_sys_nanosec + cpu.usage_user_nanosec
+	}
+	return all
+}
+
+// COPIED FROM prometheus/procfs WHICH ALSO USES APACHE 2.0
+// ReadFileNoStat uses ioutil.ReadAll to read contents of entire file.
+// This is similar to ioutil.ReadFile but without the call to os.Stat, because
+// many files in /proc and /sys report incorrect file sizes (either 0 or 4096).
+// Reads a max file size of 512kB.  For files larger than this, a scanner
+// should be used.
+func ReadFileNoStat(filename string) ([]byte, error) {
+	const maxBufferSize = 1024 * 512
+
+	f, err := os.Open(filename)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+
+	reader := io.LimitReader(f, maxBufferSize)
+	return ioutil.ReadAll(reader)
+}
+
+func cg_NewCPUAcct(cg_sub_path string) (*CPUAcct, error) {
+
+	var cpuUsage CPUAcct
+	var cpuTest CPUUsageOne
+
+	var cg_path = "/sys/fs/cgroup/cpu" + cg_sub_path + "/cpuacct.usage_all"
+	log.Debugf("CPU hierarchy path %s", cg_path)
+
+	cpuTest.cpu_id = 0
+
+	// Example cpuacct.usage_all
+	// cpu user system
+	// 0 21165924 0
+	// 1 13334251 0
+	b, err := ReadFileNoStat(cg_path)
+	if err != nil {
+		return nil, errors.Wrapf(err, "Unable to read file %s", cg_path)
+	}
+
+	scanner := bufio.NewScanner(bytes.NewReader(b))
+	scanner.Scan()
+	for scanner.Scan() {
+		text := scanner.Text()
+		vals := strings.Split(text, " ")
+		if len(vals) != 3 {
+			return nil, errors.Wrapf(err, "Unable to parse contents of file %s", cg_path)
+		}
+		cpu, err := strconv.ParseUint(vals[0], 10, 32)
+		if err != nil {
+			return nil, errors.Wrapf(err, "Unable to parse %s as uint32 (from %s)", vals[0], cg_path)
+		}
+		user, err := strconv.ParseUint(vals[1], 10, 64)
+		if err != nil {
+			return nil, errors.Wrapf(err, "Unable to parse %s as uint64 (from %s)", vals[1], cg_path)
+		}
+		sys, err := strconv.ParseUint(vals[2], 10, 64)
+		if err != nil {
+			return nil, errors.Wrapf(err, "Unable to parse %s as an in (from %s)", vals[2], cg_path)
+		}
+		var onecpu CPUUsageOne
+		onecpu.cpu_id = uint32(cpu)
+		onecpu.usage_user_nanosec = user
+		onecpu.usage_sys_nanosec = sys
+		cpuUsage.cpu = append(cpuUsage.cpu, onecpu)
+	}
+	if len(cpuUsage.cpu) < 1 {
+		return nil, errors.Wrapf(err, "Found no CPUs information inside %s", cg_path)
+	}
+
+	return &cpuUsage, nil
+}

--- a/systemd/cgroups.go
+++ b/systemd/cgroups.go
@@ -15,7 +15,7 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-// CgroupUnified constant values describe how cgroup filesystems (aka hierarchies) are
+// cgUnifiedMountMode constant values describe how cgroup filesystems (aka hierarchies) are
 // mounted underneath /sys/fs/cgroup. In cgroups-v1 there are many mounts,
 // one per controller (cpu, blkio, etc) and one for systemd itself. In
 // cgroups-v2 there is only one mount managed entirely by systemd and
@@ -23,28 +23,31 @@ import (
 // cgroups-v2, systemd has a hybrid mode where it mounts v2 and uses
 // that for process management but also mounts all the v1 filesystem
 // hierarchies and uses them for resource accounting and control
-type CgroupUnified int8
+type cgUnifiedMountMode int8
 
 const (
-	// CgroupUnifiedNone indicates that both systemd and the controllers
+	// unifModeUnknown indicates that we do not know if/how any
+	// cgroup filesystems are mounted underneath /sys/fs/cgroup
+	unifModeUnknown cgUnifiedMountMode = iota
+	// unifModeNone indicates that both systemd and the controllers
 	// are using v1 legacy mounts and there is no usage of the v2
 	// unified hierarchy. a.k.a "legacy hierarchy"
-	CgroupUnifiedNone CgroupUnified = iota
-	// CgroupUnifiedSystemd indicates that systemd is using a v2 unified
+	unifModeNone cgUnifiedMountMode = iota
+	// unifModeSystemd indicates that systemd is using a v2 unified
 	// hierarcy for organizing processes into control groups, but all
 	// controller interaction is using v1 per-controller hierarchies.
 	// a.k.a. "hybrid hierarchy"
-	CgroupUnifiedSystemd CgroupUnified = iota
-	// CgroupUnifiedAll indicates that v2 API is in full usage and there
+	unifModeSystemd cgUnifiedMountMode = iota
+	// unifModeAll indicates that v2 API is in full usage and there
 	// are no v1 hierarchies exported. Programs (mainly container orchestrators
 	// such as docker,runc,etc) that rely on v1 APIs will be broken.
 	// a.k.a. "unified hierarchy"
-	CgroupUnifiedAll CgroupUnified = iota
+	unifModeAll cgUnifiedMountMode = iota
 )
 
 // WARNING: We only read this data once at process start, systemd updates
 // may require restarting systemd-exporter
-var cgroupUnified *CgroupUnified = nil
+var cgroupUnified cgUnifiedMountMode = unifModeUnknown
 
 // Values copied from https://github.com/torvalds/linux/blob/master/include/uapi/linux/magic.h
 const (
@@ -61,47 +64,46 @@ const (
 // to track this
 // WARNING: We cache this data once at process start. Systemd updates
 // may require restarting systemd-exporter
-func cgUnifiedCached() (*CgroupUnified, error) {
-	if cgroupUnified != nil {
+func cgUnifiedCached() (cgUnifiedMountMode, error) {
+	if cgroupUnified != unifModeUnknown {
 		return cgroupUnified, nil
 	}
 
 	var fs unix.Statfs_t
 	err := unix.Statfs("/sys/fs/cgroup/", &fs)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed statfs(/sys/fs/cgroup)")
+		return unifModeUnknown, errors.Wrapf(err, "failed statfs(/sys/fs/cgroup)")
 	}
 
-	none, systemd, all := CgroupUnifiedNone, CgroupUnifiedSystemd, CgroupUnifiedAll
 	switch fs.Type {
 	case CGROUP2_SUPER_MAGIC:
 		log.Debugf("Found cgroup2 on /sys/fs/cgroup, full unified hierarchy")
-		cgroupUnified = &all
+		cgroupUnified = unifModeAll
 	case TMPFS_MAGIC:
 		err := unix.Statfs("/sys/fs/cgroup/unified", &fs)
 
 		// Ignore err, we expect path to be missing on v232
 		if err == nil && fs.Type == CGROUP2_SUPER_MAGIC {
 			log.Debugf("Found cgroup2 on /sys/fs/cgroup/systemd, unified hierarchy for systemd controller")
-			cgroupUnified = &systemd
+			cgroupUnified = unifModeSystemd
 		} else {
 			err := unix.Statfs("/sys/fs/cgroup/systemd", &fs)
 			if err != nil {
-				return nil, errors.Wrapf(err, "failed statfs(/sys/fs/cgroup/systemd)")
+				return unifModeUnknown, errors.Wrapf(err, "failed statfs(/sys/fs/cgroup/systemd)")
 			}
 			switch fs.Type {
 			case CGROUP2_SUPER_MAGIC:
 				log.Debugf("Found cgroup2 on /sys/fs/cgroup/systemd, unified hierarchy for systemd controller (v232 variant)")
-				cgroupUnified = &systemd
+				cgroupUnified = unifModeSystemd
 			case CGROUP_SUPER_MAGIC:
 				log.Debugf("Found cgroup on /sys/fs/cgroup/systemd, legacy hierarchy")
-				cgroupUnified = &none
+				cgroupUnified = unifModeNone
 			default:
-				return nil, errors.Errorf("unknown magic number %x for fstype returned by statfs(/sys/fs/cgroup/systemd)", fs.Type)
+				return unifModeUnknown, errors.Errorf("unknown magic number %x for fstype returned by statfs(/sys/fs/cgroup/systemd)", fs.Type)
 			}
 		}
 	default:
-		return nil, errors.Errorf("unknown magic number %x for fstype returned by statfs(/sys/fs/cgroup)", fs.Type)
+		return unifModeUnknown, errors.Errorf("unknown magic number %x for fstype returned by statfs(/sys/fs/cgroup)", fs.Type)
 	}
 
 	return cgroupUnified, nil
@@ -124,11 +126,13 @@ func cgGetPath(controller string, subpath string, suffix string) (*string, error
 	dn := controller
 
 	joined := ""
-	switch *unified {
-	case CgroupUnifiedNone, CgroupUnifiedSystemd:
+	switch unified {
+	case unifModeNone, unifModeSystemd:
 		joined = filepath.Join("/sys/fs/cgroup", dn, subpath, suffix)
-	case CgroupUnifiedAll:
+	case unifModeAll:
 		joined = filepath.Join("/sys/fs/cgroup", subpath, suffix)
+	default:
+		return nil, errors.Errorf("unknown cgroup mount mode (e.g. unified mode) %d", unified)
 	}
 	return &joined, nil
 }

--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -544,9 +544,8 @@ func (c *Collector) collectUnitCPUUsageMetrics(unitType string, conn *dbus.Conn,
 		if unitType == "Socket" {
 			log.Debugf("unable to read SocketUnit CPU accounting information (unit=%s)", unit.Name)
 			return nil
-		} else {
-			return errors.Wrapf(err, errControlGroupReadMsg, "CPU usage")
 		}
+		return errors.Wrapf(err, errControlGroupReadMsg, "CPU usage")
 	}
 
 	userSeconds := float64(cpuUsage.UsageUserNanosecs()) / 1000000000.0

--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -239,7 +239,6 @@ func (c *Collector) collect(ch chan<- prometheus.Metric) error {
 
 	for _, unit := range units {
 		logger := c.logger.With("unit", unit.Name)
-		c.logger = c.logger.With("unit", unit.Name)
 
 		// Collect unit_state for all
 		err := c.collectUnitState(conn, ch, unit)
@@ -503,16 +502,16 @@ func (c *Collector) collectUnitCPUUsageMetrics(unitType string, conn *dbus.Conn,
 	if err != nil {
 		return errors.Wrapf(err, errGetPropertyMsg, "ControlGroup")
 	}
-	CGSubpath, ok := propCGSubpath.Value.Value().(string)
+	cgSubpath, ok := propCGSubpath.Value.Value().(string)
 	if !ok {
 		return errors.Errorf(errConvertStringPropertyMsg, "ControlGroup", propCGSubpath.Value.Value())
 	}
 
-	if CGSubpath == "" && unit.ActiveState == "inactive" {
+	if cgSubpath == "" && unit.ActiveState == "inactive" {
 		// This is an expected condition in most cases, systemd has cleaned up
 		// and all accounting info for this unit is gone. We have nothing to record
 		return nil
-	} else if CGSubpath == "" && unit.ActiveState != "inactive" {
+	} else if cgSubpath == "" && unit.ActiveState != "inactive" {
 		// Unexpected. Why is there no cgroup on an active unit?
 		subType := c.mustGetUnitStringTypeProperty(unitType, "Type", "unknown", conn, unit)
 		slice := c.mustGetUnitStringTypeProperty(unitType, "Slice", "unknown", conn, unit)
@@ -532,7 +531,7 @@ func (c *Collector) collectUnitCPUUsageMetrics(unitType string, conn *dbus.Conn,
 		return nil
 	}
 
-	cpuUsage, err := NewCPUAcct(CGSubpath)
+	cpuUsage, err := NewCPUAcct(cgSubpath)
 	if err != nil {
 		return errors.Wrapf(err, errControlGroupReadMsg, "CPU usage")
 	}

--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -288,7 +288,7 @@ func (c *SystemdCollector) collect(ch chan<- prometheus.Metric) error {
 			if err != nil {
 				logger.Warnf(errUnitMetricsMsg, err)
 			}
-		case strings.HasSuffix(unit.Name, ".trigger"):
+		case strings.HasSuffix(unit.Name, ".timer"):
 			err := c.collectTimerTriggerTime(conn, ch, unit)
 			if err != nil {
 				logger.Warnf(errUnitMetricsMsg, err)

--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -238,80 +238,81 @@ func (c *Collector) collect(ch chan<- prometheus.Metric) error {
 	c.logger.Debugf("systemd filterUnits took %f", time.Since(begin).Seconds())
 
 	for _, unit := range units {
+		logger := c.logger.With("unit", unit.Name)
 		c.logger = c.logger.With("unit", unit.Name)
 
 		// Collect unit_state for all
 		err := c.collectUnitState(conn, ch, unit)
 		if err != nil {
-			c.logger.Warnf(errUnitMetricsMsg, err)
+			logger.Warnf(errUnitMetricsMsg, err)
 		}
 
 		switch {
 		case strings.HasSuffix(unit.Name, ".service"):
 			err = c.collectServiceMetainfo(conn, ch, unit)
 			if err != nil {
-				c.logger.Warnf(errUnitMetricsMsg, err)
+				logger.Warnf(errUnitMetricsMsg, err)
 			}
 
 			err = c.collectServiceStartTimeMetrics(conn, ch, unit)
 			if err != nil {
-				c.logger.Warnf(errUnitMetricsMsg, err)
+				logger.Warnf(errUnitMetricsMsg, err)
 			}
 
 			if *enableRestartsMetrics {
 				err = c.collectServiceRestartCount(conn, ch, unit)
 				if err != nil {
-					c.logger.Warnf(errUnitMetricsMsg, err)
+					logger.Warnf(errUnitMetricsMsg, err)
 				}
 			}
 
 			err = c.collectServiceTasksMetrics(conn, ch, unit)
 			if err != nil {
-				c.logger.Warnf(errUnitMetricsMsg, err)
+				logger.Warnf(errUnitMetricsMsg, err)
 			}
 
 			err = c.collectServiceProcessMetrics(conn, ch, unit)
 			if err != nil {
-				c.logger.Warnf(errUnitMetricsMsg, err)
+				logger.Warnf(errUnitMetricsMsg, err)
 			}
 			err = c.collectUnitCPUUsageMetrics("Service", conn, ch, unit)
 			if err != nil {
-				c.logger.Warnf(errUnitMetricsMsg, err)
+				logger.Warnf(errUnitMetricsMsg, err)
 			}
 		case strings.HasSuffix(unit.Name, ".mount"):
 			err = c.collectMountMetainfo(conn, ch, unit)
 			if err != nil {
-				c.logger.Warnf(errUnitMetricsMsg, err)
+				logger.Warnf(errUnitMetricsMsg, err)
 			}
 			err = c.collectUnitCPUUsageMetrics("Service", conn, ch, unit)
 			if err != nil {
-				c.logger.Warnf(errUnitMetricsMsg, err)
+				logger.Warnf(errUnitMetricsMsg, err)
 			}
 		case strings.HasSuffix(unit.Name, ".timer"):
 			err := c.collectTimerTriggerTime(conn, ch, unit)
 			if err != nil {
-				c.logger.Warnf(errUnitMetricsMsg, err)
+				logger.Warnf(errUnitMetricsMsg, err)
 			}
 		case strings.HasSuffix(unit.Name, ".socket"):
 			err := c.collectSocketConnMetrics(conn, ch, unit)
 			if err != nil {
-				c.logger.Warnf(errUnitMetricsMsg, err)
+				logger.Warnf(errUnitMetricsMsg, err)
 			}
 			// Most sockets do not have a cpu cgroupfs entry, but a
 			// few do, notably docker.socket
 			err = c.collectUnitCPUUsageMetrics("Socket", conn, ch, unit)
 			if err != nil {
-				c.logger.Warnf(errUnitMetricsMsg, err)
+				logger.Warnf(errUnitMetricsMsg, err)
 			}
 		case strings.HasSuffix(unit.Name, ".swap"):
 			err = c.collectUnitCPUUsageMetrics("Swap", conn, ch, unit)
 			if err != nil {
-				c.logger.Warnf(errUnitMetricsMsg, err)
+				logger.Warnf(errUnitMetricsMsg, err)
 			}
 		case strings.HasSuffix(unit.Name, ".slice"):
 			err = c.collectUnitCPUUsageMetrics("Slice", conn, ch, unit)
 			if err != nil {
-				c.logger.Warnf(errUnitMetricsMsg, err)
+				logger.Warnf(errUnitMetricsMsg, err)
 			}
 		default:
 			c.logger.Debugf(infoUnitNoHandler, unit.Name)

--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -541,7 +541,12 @@ func (c *Collector) collectUnitCPUUsageMetrics(unitType string, conn *dbus.Conn,
 
 	cpuUsage, err := NewCPUAcct(cgSubpath)
 	if err != nil {
-		return errors.Wrapf(err, errControlGroupReadMsg, "CPU usage")
+		if unitType == "Socket" {
+			log.Debugf("unable to read SocketUnit CPU accounting information (unit=%s)", unit.Name)
+			return nil
+		} else {
+			return errors.Wrapf(err, errControlGroupReadMsg, "CPU usage")
+		}
 	}
 
 	userSeconds := float64(cpuUsage.UsageUserNanosecs()) / 1000000000.0

--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -536,8 +536,8 @@ func (c *Collector) collectUnitCPUUsageMetrics(unitType string, conn *dbus.Conn,
 		return errors.Wrapf(err, errControlGroupReadMsg, "CPU usage")
 	}
 
-	userSeconds := float64(cpuUsage.UsageUser()) / 1000000000.0
-	sysSeconds := float64(cpuUsage.UsageSystem()) / 1000000000.0
+	userSeconds := float64(cpuUsage.UsageUserNanosecs()) / 1000000000.0
+	sysSeconds := float64(cpuUsage.UsageSystemNanosecs()) / 1000000000.0
 
 	ch <- prometheus.MustNewConstMetric(
 		c.unitCPUTotal, prometheus.CounterValue,

--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -38,7 +38,7 @@ var (
 
 type Collector struct {
 	logger                        log.Logger
-	unitDesc                      *prometheus.Desc
+	unitState                     *prometheus.Desc
 	unitStartTimeDesc             *prometheus.Desc
 	unitTasksCurrentDesc          *prometheus.Desc
 	unitTasksMaxDesc              *prometheus.Desc
@@ -60,7 +60,7 @@ type Collector struct {
 
 // NewCollector returns a new Collector exposing systemd statistics.
 func NewCollector(logger log.Logger) (*Collector, error) {
-	unitDesc := prometheus.NewDesc(
+	unitState := prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, "", "unit_state"),
 		"Systemd unit", []string{"name", "state", "type"}, nil,
 	)
@@ -131,7 +131,7 @@ func NewCollector(logger log.Logger) (*Collector, error) {
 
 	return &Collector{
 		logger:                        logger,
-		unitDesc:                      unitDesc,
+		unitState:                     unitState,
 		unitStartTimeDesc:             unitStartTimeDesc,
 		unitTasksCurrentDesc:          unitTasksCurrentDesc,
 		unitTasksMaxDesc:              unitTasksMaxDesc,
@@ -161,7 +161,7 @@ func (c *Collector) Collect(ch chan<- prometheus.Metric) {
 
 // Describe gathers descriptions of Metrics
 func (c *Collector) Describe(desc chan<- *prometheus.Desc) {
-	desc <- c.unitDesc
+	desc <- c.unitState
 	desc <- c.unitStartTimeDesc
 	desc <- c.unitTasksCurrentDesc
 	desc <- c.unitTasksMaxDesc
@@ -267,7 +267,7 @@ func (c *Collector) collectMountState(conn *dbus.Conn, ch chan<- prometheus.Metr
 			isActive = 1.0
 		}
 		ch <- prometheus.MustNewConstMetric(
-			c.unitDesc, prometheus.GaugeValue, isActive,
+			c.unitState, prometheus.GaugeValue, isActive,
 			unit.Name, stateName, serviceType)
 	}
 
@@ -290,7 +290,7 @@ func (c *Collector) collectServiceState(conn *dbus.Conn, ch chan<- prometheus.Me
 			isActive = 1.0
 		}
 		ch <- prometheus.MustNewConstMetric(
-			c.unitDesc, prometheus.GaugeValue, isActive,
+			c.unitState, prometheus.GaugeValue, isActive,
 			unit.Name, stateName, serviceType)
 	}
 

--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -19,7 +19,7 @@ const namespace = "systemd"
 
 var (
 	unitWhitelist         = kingpin.Flag("collector.unit-whitelist", "Regexp of systemd units to whitelist. Units must both match whitelist and not match blacklist to be included.").Default(".+").String()
-	unitBlacklist         = kingpin.Flag("collector.unit-blacklist", "Regexp of systemd units to blacklist. Units must both match whitelist and not match blacklist to be included.").Default(".+\\.(automount|device|mount|scope|slice)").String()
+	unitBlacklist         = kingpin.Flag("collector.unit-blacklist", "Regexp of systemd units to blacklist. Units must both match whitelist and not match blacklist to be included.").Default(".+\\.(device)").String()
 	systemdPrivate        = kingpin.Flag("collector.private", "Establish a private, direct connection to systemd without dbus.").Bool()
 	procPath              = kingpin.Flag("path.procfs", "procfs mountpoint.").Default(procfs.DefaultMountPoint).String()
 	enableRestartsMetrics = kingpin.Flag("collector.enable-restart-count", "Enables service restart count metrics. This feature only works with systemd 235 and above.").Bool()

--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -507,16 +507,16 @@ func (c *Collector) collectUnitCPUUsageMetrics(unitType string, conn *dbus.Conn,
 		return errors.Errorf(errConvertStringPropertyMsg, "ControlGroup", propCGSubpath.Value.Value())
 	}
 
-	if cgSubpath == "" && unit.ActiveState == "inactive" {
+	switch {
+	case cgSubpath == "" && unit.ActiveState == "inactive":
 		// This is an expected condition in most cases, systemd has cleaned up
 		// and all accounting info for this unit is gone. We have nothing to record
 		return nil
-	} else if cgSubpath == "" && unit.ActiveState != "inactive" {
+	case cgSubpath == "" && unit.ActiveState != "inactive":
 		// Unexpected. Why is there no cgroup on an active unit?
 		subType := c.mustGetUnitStringTypeProperty(unitType, "Type", "unknown", conn, unit)
 		slice := c.mustGetUnitStringTypeProperty(unitType, "Slice", "unknown", conn, unit)
-		return errors.Errorf("got 'no cgroup' from systemd for active unit (state=%s subtype=%s slice=%s)",
-			unit.ActiveState, subType, slice)
+		return errors.Errorf("got 'no cgroup' from systemd for active unit (state=%s subtype=%s slice=%s)", unit.ActiveState, subType, slice)
 	}
 
 	propCPUAcct, err := conn.GetUnitTypeProperty(unit.Name, unitType, "CPUAccounting")
@@ -527,7 +527,7 @@ func (c *Collector) collectUnitCPUUsageMetrics(unitType string, conn *dbus.Conn,
 	if !ok {
 		return errors.Errorf(errConvertStringPropertyMsg, "CPUAccounting", propCPUAcct.Value.Value())
 	}
-	if cpuAcct == false {
+	if !cpuAcct {
 		return nil
 	}
 

--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -1,15 +1,9 @@
 package systemd
 
 import (
-	"bufio"
-	"bytes"
 	"fmt"
-	"io"
-	"io/ioutil"
 	"math"
-	"os"
 	"regexp"
-	"strconv"
 	"strings"
 	"time"
 
@@ -406,112 +400,6 @@ func (c *systemdCollector) collectServiceStartTimeMetrics(conn *dbus.Conn, ch ch
 		float64(startTimeUsec)/1e6, unit.Name)
 
 	return nil
-}
-
-type CPUUsageOne struct {
-	cpu_id             uint32
-	usage_sys_nanosec  uint64
-	usage_user_nanosec uint64
-}
-
-// Holds contents of /sys/fs/cgroup/..../cpuacct.usage_all
-type CPUAcct struct {
-	cpu []CPUUsageOne
-}
-
-func (c *CPUAcct) usage_user_nanosec() uint64 {
-	var all uint64
-	for _, cpu := range c.cpu {
-		all += cpu.usage_user_nanosec
-	}
-	return all
-}
-
-func (c *CPUAcct) usage_sys_nanosec() uint64 {
-	var all uint64
-	for _, cpu := range c.cpu {
-		all += cpu.usage_sys_nanosec
-	}
-	return all
-}
-
-func (c *CPUAcct) usage_all_nanosec() uint64 {
-	var all uint64
-	for _, cpu := range c.cpu {
-		all += cpu.usage_sys_nanosec + cpu.usage_user_nanosec
-	}
-	return all
-}
-
-// COPIED FROM prometheus/procfs WHICH ALSO USES APACHE 2.0
-// ReadFileNoStat uses ioutil.ReadAll to read contents of entire file.
-// This is similar to ioutil.ReadFile but without the call to os.Stat, because
-// many files in /proc and /sys report incorrect file sizes (either 0 or 4096).
-// Reads a max file size of 512kB.  For files larger than this, a scanner
-// should be used.
-func ReadFileNoStat(filename string) ([]byte, error) {
-	const maxBufferSize = 1024 * 512
-
-	f, err := os.Open(filename)
-	if err != nil {
-		return nil, err
-	}
-	defer f.Close()
-
-	reader := io.LimitReader(f, maxBufferSize)
-	return ioutil.ReadAll(reader)
-}
-
-func cg_NewCPUAcct(cg_sub_path string) (*CPUAcct, error) {
-
-	var cpuUsage CPUAcct
-	var cpuTest CPUUsageOne
-
-	var cg_path = "/sys/fs/cgroup/cpu" + cg_sub_path + "/cpuacct.usage_all"
-	log.Debugf("CPU hierarchy path %s", cg_path)
-
-	cpuTest.cpu_id = 0
-
-	// Example cpuacct.usage_all
-	// cpu user system
-	// 0 21165924 0
-	// 1 13334251 0
-	b, err := ReadFileNoStat(cg_path)
-	if err != nil {
-		return nil, errors.Wrapf(err, "Unable to read file %s", cg_path)
-	}
-
-	scanner := bufio.NewScanner(bytes.NewReader(b))
-	scanner.Scan()
-	for scanner.Scan() {
-		text := scanner.Text()
-		vals := strings.Split(text, " ")
-		if len(vals) != 3 {
-			return nil, errors.Wrapf(err, "Unable to parse contents of file %s", cg_path)
-		}
-		cpu, err := strconv.ParseUint(vals[0], 10, 32)
-		if err != nil {
-			return nil, errors.Wrapf(err, "Unable to parse %s as uint32 (from %s)", vals[0], cg_path)
-		}
-		user, err := strconv.ParseUint(vals[1], 10, 64)
-		if err != nil {
-			return nil, errors.Wrapf(err, "Unable to parse %s as uint64 (from %s)", vals[1], cg_path)
-		}
-		sys, err := strconv.ParseUint(vals[2], 10, 64)
-		if err != nil {
-			return nil, errors.Wrapf(err, "Unable to parse %s as an in (from %s)", vals[2], cg_path)
-		}
-		var onecpu CPUUsageOne
-		onecpu.cpu_id = uint32(cpu)
-		onecpu.usage_user_nanosec = user
-		onecpu.usage_sys_nanosec = sys
-		cpuUsage.cpu = append(cpuUsage.cpu, onecpu)
-	}
-	if len(cpuUsage.cpu) < 1 {
-		return nil, errors.Wrapf(err, "Found no CPUs information inside %s", cg_path)
-	}
-
-	return &cpuUsage, nil
 }
 
 func (c *systemdCollector) collectServiceProcessMetrics(conn *dbus.Conn, ch chan<- prometheus.Metric, unit dbus.UnitStatus) error {

--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -34,7 +34,7 @@ var (
 	errConvertUint32PropertyMsg = "couldn't convert unit's %s property %v to uint32"
 	errConvertStringPropertyMsg = "couldn't convert unit's %s property %v to string"
 	errUnitMetricsMsg           = "couldn't get unit's metrics: %s"
-	errControlGroupReadMsg      = "Failed to read %s from control group"
+	errControlGroupReadMsg      = "failed to read %s from control group"
 	infoUnitNoHandler           = "no unit type handler for %s"
 )
 
@@ -70,16 +70,16 @@ func NewCollector(logger log.Logger) (*Collector, error) {
 		prometheus.BuildFQName(namespace, "", "unit_state"),
 		"Systemd unit", []string{"name", "type", "state"}, nil,
 	)
-	// TODO think about if we want to have 1) one unit_info metric which has all possible labels 
-	// for all possible unit type variables (at least, the relatively static ones that we care 
-	// about such as type, generated-vs-real-unit, etc). Cons: a) huge waste since all these labels 
-	// have to be set to foo="" on non-relevant types. b) accidental overloading (e.g. we have type 
-	// label, but it means something differnet for a service vs a mount. Right now it's impossible to 
-	// detangle that. 
+	// TODO think about if we want to have 1) one unit_info metric which has all possible labels
+	// for all possible unit type variables (at least, the relatively static ones that we care
+	// about such as type, generated-vs-real-unit, etc). Cons: a) huge waste since all these labels
+	// have to be set to foo="" on non-relevant types. b) accidental overloading (e.g. we have type
+	// label, but it means something differnet for a service vs a mount. Right now it's impossible to
+	// detangle that.
 	// Option 1) is we have service_info, mount_info, target_info, etc. Many more metrics, but far fewer
-	// wasted labels and little chance of semantic confusion. Our current codebase is not tuned for this, 
+	// wasted labels and little chance of semantic confusion. Our current codebase is not tuned for this,
 	// we would be adding likt 30% more lines of just boilerplate to declare these different metrics
-	// w.r.t. cardinality and performance, option 2 is slightly better performance due to smaller scrape payloads 
+	// w.r.t. cardinality and performance, option 2 is slightly better performance due to smaller scrape payloads
 	// but otherwise (1) and (2) seem similar
 	unitInfo := prometheus.NewDesc(
 		prometheus.BuildFQName(namespace, "", "unit_info"),
@@ -229,7 +229,7 @@ func (c *Collector) collect(ch chan<- prometheus.Metric) error {
 
 	allUnits, err := conn.ListUnits()
 	if err != nil {
-		return errors.Wrap(err, "Could not get list of systemd units from dbus")
+		return errors.Wrap(err, "could not get list of systemd units from dbus")
 	}
 
 	c.logger.Debugf("systemd getAllUnits took %f", time.Since(begin).Seconds())
@@ -515,7 +515,7 @@ func (c *Collector) collectUnitCPUUsageMetrics(unitType string, conn *dbus.Conn,
 		// Unexpected. Why is there no cgroup on an active unit?
 		subType := c.mustGetUnitStringTypeProperty(unitType, "Type", "unknown", conn, unit)
 		slice := c.mustGetUnitStringTypeProperty(unitType, "Slice", "unknown", conn, unit)
-		return errors.Errorf("Got 'no cgroup' from systemd for active unit (state=%s subtype=%s slice=%s)",
+		return errors.Errorf("got 'no cgroup' from systemd for active unit (state=%s subtype=%s slice=%s)",
 			unit.ActiveState, subType, slice)
 	}
 

--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -238,81 +238,80 @@ func (c *SystemdCollector) collect(ch chan<- prometheus.Metric) error {
 	c.logger.Debugf("systemd filterUnits took %f", time.Since(begin).Seconds())
 
 	for _, unit := range units {
-		logger := c.logger.With("unit", unit.Name)
 		c.logger = c.logger.With("unit", unit.Name)
 
 		// Collect unit_state for all
 		err := c.collectUnitState(conn, ch, unit)
 		if err != nil {
-			logger.Warnf(errUnitMetricsMsg, err)
+			c.logger.Warnf(errUnitMetricsMsg, err)
 		}
 
 		switch {
 		case strings.HasSuffix(unit.Name, ".service"):
 			err = c.collectServiceMetainfo(conn, ch, unit)
 			if err != nil {
-				logger.Warnf(errUnitMetricsMsg, err)
+				c.logger.Warnf(errUnitMetricsMsg, err)
 			}
 
 			err = c.collectServiceStartTimeMetrics(conn, ch, unit)
 			if err != nil {
-				logger.Warnf(errUnitMetricsMsg, err)
+				c.logger.Warnf(errUnitMetricsMsg, err)
 			}
 
 			if *enableRestartsMetrics {
 				err = c.collectServiceRestartCount(conn, ch, unit)
 				if err != nil {
-					logger.Warnf(errUnitMetricsMsg, err)
+					c.logger.Warnf(errUnitMetricsMsg, err)
 				}
 			}
 
 			err = c.collectServiceTasksMetrics(conn, ch, unit)
 			if err != nil {
-				logger.Warnf(errUnitMetricsMsg, err)
+				c.logger.Warnf(errUnitMetricsMsg, err)
 			}
 
 			err = c.collectServiceProcessMetrics(conn, ch, unit)
 			if err != nil {
-				logger.Warnf(errUnitMetricsMsg, err)
+				c.logger.Warnf(errUnitMetricsMsg, err)
 			}
 			err = c.collectUnitCPUUsageMetrics("Service", conn, ch, unit)
 			if err != nil {
-				logger.Warnf(errUnitMetricsMsg, err)
+				c.logger.Warnf(errUnitMetricsMsg, err)
 			}
 		case strings.HasSuffix(unit.Name, ".mount"):
 			err = c.collectMountMetainfo(conn, ch, unit)
 			if err != nil {
-				logger.Warnf(errUnitMetricsMsg, err)
+				c.logger.Warnf(errUnitMetricsMsg, err)
 			}
 			err = c.collectUnitCPUUsageMetrics("Service", conn, ch, unit)
 			if err != nil {
-				logger.Warnf(errUnitMetricsMsg, err)
+				c.logger.Warnf(errUnitMetricsMsg, err)
 			}
 		case strings.HasSuffix(unit.Name, ".timer"):
 			err := c.collectTimerTriggerTime(conn, ch, unit)
 			if err != nil {
-				logger.Warnf(errUnitMetricsMsg, err)
+				c.logger.Warnf(errUnitMetricsMsg, err)
 			}
 		case strings.HasSuffix(unit.Name, ".socket"):
 			err := c.collectSocketConnMetrics(conn, ch, unit)
 			if err != nil {
-				logger.Warnf(errUnitMetricsMsg, err)
+				c.logger.Warnf(errUnitMetricsMsg, err)
 			}
 			// Most sockets do not have a cpu cgroupfs entry, but a
 			// few do, notably docker.socket
 			err = c.collectUnitCPUUsageMetrics("Socket", conn, ch, unit)
 			if err != nil {
-				logger.Warnf(errUnitMetricsMsg, err)
+				c.logger.Warnf(errUnitMetricsMsg, err)
 			}
 		case strings.HasSuffix(unit.Name, ".swap"):
 			err = c.collectUnitCPUUsageMetrics("Swap", conn, ch, unit)
 			if err != nil {
-				logger.Warnf(errUnitMetricsMsg, err)
+				c.logger.Warnf(errUnitMetricsMsg, err)
 			}
 		case strings.HasSuffix(unit.Name, ".slice"):
 			err = c.collectUnitCPUUsageMetrics("Slice", conn, ch, unit)
 			if err != nil {
-				logger.Warnf(errUnitMetricsMsg, err)
+				c.logger.Warnf(errUnitMetricsMsg, err)
 			}
 		default:
 			c.logger.Debugf(infoUnitNoHandler, unit.Name)

--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -283,7 +283,7 @@ func (c *Collector) collect(ch chan<- prometheus.Metric) error {
 			if err != nil {
 				logger.Warnf(errUnitMetricsMsg, err)
 			}
-			err = c.collectUnitCPUUsageMetrics("Service", conn, ch, unit)
+			err = c.collectUnitCPUUsageMetrics("Mount", conn, ch, unit)
 			if err != nil {
 				logger.Warnf(errUnitMetricsMsg, err)
 			}

--- a/systemd/systemd.go
+++ b/systemd/systemd.go
@@ -199,6 +199,12 @@ func (c *Collector) collect(ch chan<- prometheus.Metric) error {
 	for _, unit := range units {
 		logger := c.logger.With("unit", unit.Name)
 
+		// Collect basic state info for all units
+		err := c.collectUnitState(conn, ch, unit)
+		if err != nil {
+			logger.Warnf(errUnitMetricsMsg, err)
+		}
+
 		switch {
 		case strings.HasSuffix(unit.Name, ".service"):
 			err = c.collectServiceState(conn, ch, unit)
@@ -243,7 +249,26 @@ func (c *Collector) collect(ch chan<- prometheus.Metric) error {
 			if err != nil {
 				logger.Warnf(errUnitMetricsMsg, err)
 			}
+		default:
+			c.logger.Debugf(infoUnitNoHandler, unit.Name)
 		}
+	}
+
+	return nil
+}
+
+func (c *Collector) collectUnitState(conn *dbus.Conn, ch chan<- prometheus.Metric, unit dbus.UnitStatus) error {
+	//TODO: wrap GetUnitTypePropertyString(
+	// serviceTypeProperty, err := conn.GetUnitTypeProperty(unit.Name, "Timer", "NextElapseUSecMonotonic")
+
+	for _, stateName := range unitStatesName {
+		isActive := 0.0
+		if stateName == unit.ActiveState {
+			isActive = 1.0
+		}
+		ch <- prometheus.MustNewConstMetric(
+			c.unitState, prometheus.GaugeValue, isActive,
+			unit.Name, stateName)
 	}
 
 	return nil
@@ -251,6 +276,7 @@ func (c *Collector) collect(ch chan<- prometheus.Metric) error {
 
 func (c *Collector) collectMountState(conn *dbus.Conn, ch chan<- prometheus.Metric, unit dbus.UnitStatus) error {
 	//TODO: wrap GetUnitTypePropertyString(
+	/*
 	serviceTypeProperty, err := conn.GetUnitTypeProperty(unit.Name, "Mount", "Type")
 	if err != nil {
 		return errors.Wrapf(err, errGetPropertyMsg, "Type")
@@ -270,11 +296,13 @@ func (c *Collector) collectMountState(conn *dbus.Conn, ch chan<- prometheus.Metr
 			c.unitState, prometheus.GaugeValue, isActive,
 			unit.Name, stateName, serviceType)
 	}
+	*/
 
 	return nil
 }
 
 func (c *Collector) collectServiceState(conn *dbus.Conn, ch chan<- prometheus.Metric, unit dbus.UnitStatus) error {
+	/*
 	serviceTypeProperty, err := conn.GetUnitTypeProperty(unit.Name, "Service", "Type")
 	if err != nil {
 		return errors.Wrapf(err, errGetPropertyMsg, "Type")
@@ -293,7 +321,7 @@ func (c *Collector) collectServiceState(conn *dbus.Conn, ch chan<- prometheus.Me
 			c.unitState, prometheus.GaugeValue, isActive,
 			unit.Name, stateName, serviceType)
 	}
-
+	*/
 	return nil
 }
 


### PR DESCRIPTION
This PR primarily adds initial support for cgroups. Currently, only CPU information is read from cgroups, as I want to get some feedback on the design + API before continuing on to memory/block-io/network/etc. The bulk of the cgroup work is isolated in a separate `cgroups.go` file, in the hopes we can someday upstream that part and gain the benefits of a broader community supporting that work. 

I have only been able to test cgroups in the 'legacy / hybrid' mode as I do not have access to a system running in 'unified' mode. It's my understanding the latest fedora runs in unified, so perhaps someone running that could help test this. The code is designed to support full unified mode.

The bulk of the heavy lifting in the cgroups work was reading the systemd source code and reversing systemd's usage of cgroups. In order to read information from the correct files, we have to know where to look. This means there is effectively an interface between systemd and "cgroup readers" such as ourselves. We need to read file data from the cgroups (e.g. directories) where systemd chooses to write. This is also true for of the kernel, which chooses names for the cgroup files. In order to help others working on ensuring `cgroups.go`'s "cgroup reader" code matches the systemd "cgroup writer" code, some of the function/variable names are intentionally chosen to mirror the variable names in the systemd source. This makes it much easier to learn both codebases and map behaviour (which cannot be directly copied, for both language and legal reasons). 

In addition to cgroups, a number of minor changes were included: 
1. Repo has a changelog now
1. [ENHANCEMENT] Added `type` label to all metrics named `systemd_unit-*` to support PromQL grouping
1. [ENHANCEMENT] Add `systemd_unit_info` with metainformation about units incl. subtype specific info
   - I'm not thrilled with this approach used by `systemd_unit_info`, it already shows issues even when only supporting two types, but it was an attempt to not lose the `type` data when fixing `systemd_unit_state`'s `type` field. I may change `unit_info` in a different PR
1. [ENHANCEMENT] `systemd_unit_state` works for all unit types, not just service and mount units
   - This change caused a significant increase in cardinality, as 5 new metrics are exported for all units. On my Ubuntu system, this PR adds adds approx 900 metrics (from the 1300 current to about 2200), with the bulk of those coming from this enhancement. Prom's team encourages metric breadth, so I am not personally concerned about this being the default  
1. [CHANGE] Start tracking metric cardinality in readme
   - This may go away in future PR, as it was intended to be a tool for me to compare this PR with current master. However the tool showed some issues so I chose to leave it in for now. Mainly, many of the metrics named `_unit` are not actually available for all units. Seems like a future PR could rename metrics as needed, either supporting all unit types for things named `unit` or changing the metric name to be specific to the unit type
1. [CHANGE] Expanded default set of unit types monitored. Only device unit types are not enabled by default
   - This change causes a minor increase in cardinality but gives us a many interesting new metrics for tracking system status. Personally very happy with this change, the cost-benefit seems to be favorable
1. [BUGFIX] `timer_last_trigger_seconds` metric is now exported as expected for all timers
   - IMO this metric is still broken, because it's using a non-monotonic clock internally and therefore is a bit harder to track restarts with PromQL, but this PR is getting out of hand so I decided to settle on making it work as is and improving it later 